### PR TITLE
perf: hashed tables for observee-subscriber sets

### DIFF
--- a/src/lua_libs/pubsub.lua
+++ b/src/lua_libs/pubsub.lua
@@ -6,31 +6,35 @@ Astra.pubsub = {}
 
 ---
 ---@param topic string
----@param observer any
+---@param observable any
 ---@param callback function
-Astra.pubsub.subscribe = function(topic, observer, callback)
+Astra.pubsub.subscribe = function(topic, observable, callback)
 	if not subscriptions[topic] then
 		subscriptions[topic] = {}
 	end
 
-	-- Subscriber table
-	table.insert(subscriptions[topic], {
-		obs = observer,
-		cbk = callback,
-	})
+	if not subscriptions[topic][observable] then
+		subscriptions[topic][observable] = {
+			num_subs = 0,
+		}
+	end
+
+	if not subscriptions[topic][observable][callback] then
+		subscriptions[topic][observable][callback] = true
+		subscriptions[topic][observable].num_subs = subscriptions[topic][observable].num_subs + 1
+	end
 end
 
 ---
 ---@param topic string
----@param observer any
+---@param observable any
 ---@param callback function
-Astra.pubsub.unsubscribe = function(topic, observer, callback)
-	for i = #subscriptions[topic], 1, -1 do
-		local sub = subscriptions[topic][i]
+Astra.pubsub.unsubscribe = function(topic, observable, callback)
+	subscriptions[topic][observable][callback] = nil
+	subscriptions[topic][observable].num_subs = subscriptions[topic][observable].num_subs - 1
 
-		if sub.obs == observer and sub.cbk == callback then
-			table.remove(subscriptions[topic], i)
-		end
+	if subscriptions[topic][observable].num_subs < 1 then
+		subscriptions[topic][observable] = nil
 	end
 end
 
@@ -38,7 +42,11 @@ end
 ---@param topic string
 ---@param data any
 Astra.pubsub.publish = function(topic, data)
-	for i = 1, #subscriptions[topic] do
-		subscriptions[topic][i].cbk(subscriptions[topic][i].obs, data)
+	for observable, kv in pairs(subscriptions[topic]) do
+		for k, v in pairs(kv) do
+			if type(v) ~= "number" then
+				k(observable, data)
+			end
+		end
 	end
 end


### PR DESCRIPTION
Hashed observee keys, children subscriber keys for near-instantaneous subscribe/unsubscribe operations

More concise and flexible internal logic as there can be no duplicate observees, and an observee can have multiple subscribers in the same table

Refs: #26