### PR TITLE
feat(net): add Unix domain socket API

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -268,6 +268,14 @@ async fn registration(lua: &mlua::Lua, stdlib_path: Option<String>) {
             tracing::error!("Couldn't add prelude:\n{e}");
         }
     }
+     // Register unix socket AFTER Lua scripts
+    #[cfg(unix)]
+    {
+        use crate::components::unix_socket::UnixSocketComponent;
+        if let Err(e) = UnixSocketComponent::register_to_lua(lua).await {
+            tracing::error!("Failed to register unix socket: {:?}", e);
+        }
+    }
 }
 
 fn pure_lua_libs() -> Vec<(String, String)> {

--- a/src/components/unix_socket.lua
+++ b/src/components/unix_socket.lua
@@ -1,0 +1,10 @@
+---@meta
+
+---@class UnixSocket
+---@field send fun(socket: UnixSocket, data: string)
+---@field receive fun(socket: UnixSocket, buffer_size: integer): string
+---@field close fun(socket: UnixSocket)
+---@field is_connected fun(socket: UnixSocket): boolean
+
+---@class _AstraUnix
+---@field connect fun(path: string): UnixSocket|nil, string|nil

--- a/src/components/unix_socket.rs
+++ b/src/components/unix_socket.rs
@@ -1,0 +1,155 @@
+use mlua::{Lua, Result, UserData, UserDataMethods};
+use std::path::Path;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::UnixStream,
+    time,
+};
+use std::time::Duration;
+
+/// Represents a Unix domain socket connection
+pub struct UnixSocket {
+    stream: Option<UnixStream>,
+}
+
+impl UnixSocket {
+    pub async fn connect(path: String) -> Result<Self> {
+        if !Self::is_safe_path(&path) {
+            return Err(mlua::Error::runtime("Access to this socket path is restricted"));
+        }
+
+
+        match time::timeout(
+            Duration::from_secs(2),
+            UnixStream::connect(Path::new(&path)),
+        )
+        .await
+        {
+            Ok(Ok(stream)) => {
+                Ok(Self {
+                    stream: Some(stream),
+                })
+            },
+            Ok(Err(e)) => {
+                Err(mlua::Error::runtime(format!(
+                    "Connection failed: {}",
+                    e
+                )))
+            },
+            Err(_) => {
+                Err(mlua::Error::runtime("Connection timed out"))
+            },
+        }
+    }
+
+    fn is_safe_path(path: &str) -> bool {
+        let allowed_prefixes = [
+            "/var/run/",
+            "/tmp/",
+            "/run/user/"
+        ];
+        allowed_prefixes.iter().any(|prefix| path.starts_with(prefix))
+    }
+
+    pub async fn send(&mut self, data: Vec<u8>) -> Result<()> {
+        let stream = match self.stream.as_mut() {
+            Some(s) => s,
+            None => return Err(mlua::Error::runtime("Socket not connected")),
+        };
+
+        match time::timeout(Duration::from_secs(5), stream.write_all(&data)).await {
+            Ok(Ok(_)) => Ok(()),
+            Ok(Err(e)) => Err(mlua::Error::runtime(format!("Write failed: {}", e))),
+            Err(_) => Err(mlua::Error::runtime("Write operation timed out")),
+        }
+    }
+
+    pub async fn receive(&mut self, buf_size: usize) -> Result<Vec<u8>> {
+        let stream = match self.stream.as_mut() {
+            Some(s) => s,
+            None => return Err(mlua::Error::runtime("Socket not connected")),
+        };
+
+        let mut buf = vec![0u8; buf_size];
+        match time::timeout(Duration::from_secs(5), stream.read(&mut buf)).await {
+            Ok(Ok(bytes_read)) => {
+                buf.truncate(bytes_read);
+                Ok(buf)
+            }
+            Ok(Err(e)) => Err(mlua::Error::runtime(format!("Read failed: {}", e))),
+            Err(_) => Err(mlua::Error::runtime("Read operation timed out")),
+        }
+    }
+
+    pub async fn close(&mut self) -> Result<()> {
+        if let Some(mut stream) = self.stream.take() {
+            let _ = time::timeout(Duration::from_secs(1), stream.shutdown()).await;
+        }
+        Ok(())
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.stream.is_some()
+    }
+}
+
+impl UserData for UnixSocket {
+    fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_async_method_mut("send", |_, mut this, data: Vec<u8>| async move {
+            this.send(data).await
+        });
+        
+        methods.add_async_method_mut("receive", |_, mut this, buf_size: usize| async move {
+            this.receive(buf_size).await
+        });
+        
+        methods.add_async_method_mut("close", |_, mut this, _: ()| async move {
+            this.close().await
+        });
+        
+        methods.add_method("is_connected", |_, this, _: ()| {
+            Ok(this.is_connected())
+        });
+    }
+}
+
+pub struct UnixSocketComponent;
+
+impl UnixSocketComponent {
+    
+    pub async fn register_to_lua(lua: &Lua) -> mlua::Result<()> {
+        // Get or create Astra table
+        let astra_table: mlua::Table = match lua.globals().get("Astra") {
+            Ok(table) => table,
+            Err(_) => {
+                let table = lua.create_table()?;
+                lua.globals().set("Astra", table.clone())?;
+                table
+
+            }
+
+        };
+
+        // Create unix subtable
+        let unix_table = lua.create_table()?;
+        unix_table.set(
+            "connect",
+            lua.create_async_function(|lua, path: String| async move {
+
+                UnixSocket::connect(path).await
+                    .and_then(|s| lua.create_userdata(s))
+
+            })?,
+
+        )?;
+        astra_table.set("unix", unix_table)?;
+
+        Ok(())
+
+    }
+
+    pub fn lua_code() -> &'static str {
+        include_str!("unix_socket.lua")
+
+    }
+}


### PR DESCRIPTION
---

## ✅ Features

- 🔐 Secure connection to socket paths: `/var/run`, `/tmp`, `/run/user`
- 📤 Full `send`, `receive`, `is_connected` and `close` functionality
- ⏱ Timeout protection on all operations

---

## 📦 Example Usage

```python
# 🖥️ server.py (Python)
import socket
import os

SOCKET_PATH = "/tmp/test-uds.sock"

# Remove the socket file if it exists
if os.path.exists(SOCKET_PATH):
    os.remove(SOCKET_PATH)

server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
server.bind(SOCKET_PATH)
server.listen(1)

print(f"Listening on {SOCKET_PATH}...")

while True:
    conn, _ = server.accept()
    data = conn.recv(1024)
    if not data:
        break
    print("Received:", data.decode())
    conn.sendall(b"ECHO: " + data)
    conn.close()
```
 
```lua
 -- 🧪 client.lua (Lua)
local path = "/tmp/test-uds.sock"
local msg = "Hello from Astra"

-- Convert string to byte table
local bytes = {}
for i = 1, #msg do
    table.insert(bytes, msg:byte(i))
end

-- Connect to the Unix socket
local sock, err = Astra.unix.connect(path)
if not sock then
    print("Socket connection failed:", err)
    return
end

print("Connected. Sending:", msg)
sock:send(bytes)

-- Receive response
local response = sock:receive(1024)
if response then
    -- Convert byte table to string
    local chars = {}
    for i = 1, #response do
        chars[i] = string.char(response[i])
    end
    local decoded = table.concat(chars)

    print("Received (decoded):", decoded)
else
    print("No response")
end

sock:close()
```

