### PR TITLE
HTTP server testing added

### DIFF
--- a/tests/http_server.lua
+++ b/tests/http_server.lua
@@ -1,0 +1,226 @@
+local PORT = 3000
+local DB_PATH = 'tests/posts_test.db'
+local mock = require("tests.mock_server")
+
+local server_task = spawn_task(function ()
+    local server = mock.create({ port = PORT, db_path = DB_PATH })
+    server:run()
+end)
+
+print('WAIT 3 SECONDS TO INITIATE THE SERVER')
+spawn_timeout(function ()
+    local lust = require 'tests.lust'
+    local describe, it, expect = lust.describe, lust.it, lust.expect
+
+    -- define the custom assertion - check str contain (not provided on lust)
+    lust.paths.contain = {
+        test = function(str, substr)
+        local ok = type(str) == 'string' and type(substr) == 'string' and str:find(substr, 1, true) ~= nil
+        return ok,
+            "expected '" .. tostring(str) .. "' to contain '" .. tostring(substr) .. "'",
+            "expected '" .. tostring(str) .. "' to not contain '" .. tostring(substr) .. "'"
+        end
+    }
+    table.insert(lust.paths.to, 'contain')
+
+    -- util
+    local function get_one_valid_id()
+        local response = Astra.http.request('http://localhost:' .. PORT .. '/posts'):execute()
+        local latest_id = response:body():json()[1].id
+        return latest_id
+    end
+
+    -- helper
+    local function post_helper(payload)
+        local response = Astra.http.request('http://localhost:' .. PORT .. '/posts')
+            :set_method('POST')
+            :set_json(payload)
+            :execute()
+
+        local status_code = response:status_code()
+        local data = response:body():json()
+        return status_code, data
+    end
+    local function get_helper(uri)
+        local response = Astra.http.request(uri)
+            :set_method('GET')
+            :execute()
+
+        local status_code = response:status_code()
+        local data = response:body():json()
+        return status_code, data
+    end
+    local function put_helper(id, payload)
+        local response = Astra.http.request('http://localhost:' .. PORT .. '/posts/' .. tostring(id))
+            :set_method('PUT')
+            :set_json(payload)
+            :execute()
+
+        local status_code = response:status_code()
+        local data = response:body():json()
+        return status_code, data
+    end
+    local function del_helper(uri)
+        local response = Astra.http.request(uri)
+            :set_method('DELETE')
+            :execute()
+
+        local status_code = response:status_code()
+        local data = response:body():json()
+        return status_code, data
+    end
+
+    -- test
+    describe('TestPostPostAPI', function()
+        -- 200: valid
+        it('testPostValidPost', function()
+            local status_code, data = post_helper({
+                author = 'tester',
+                title = 'test_ttl',
+                content = 'test_content'
+            })
+            expect(status_code).to.equal(200)
+            expect(data.status).to.equal('created')
+        end)
+
+        -- 400: missing field
+        it('testPostMissingFieldPost', function()
+            local status_code, data = post_helper({
+                author = 'tester',
+                title = 'test_ttl',
+            })
+            expect(status_code).to.equal(400)
+            expect(data.status).to_not.be.truthy()
+            expect(data.error).to.contain('Invalid input')
+        end)
+    
+        -- 400: invalid schema
+        it('testPostInvalidTypePost', function()
+            local status_code, data = post_helper({
+                author = 123,
+                content = 'test_content'
+            })
+            expect(status_code).to.equal(400)
+            expect(data.status).to_not.be.truthy()
+            expect(data.error).to.contain('Invalid input')
+        end)
+    end)
+
+    describe('TestGetPostAPI', function()
+        local uri = 'http://localhost:' .. PORT .. '/posts'
+        -- 200: valid
+        it('testGetAllPosts', function()
+            local status_code, data = get_helper(uri)
+            expect(status_code).to.equal(200)
+            expect(data).to.be.a('table')
+            if #data > 0 then
+                expect(data[1].author).to.be.a('string')
+                expect(data[1].content).to.be.a('string')
+                expect(data[1].timestamp).to.be.a('number')
+            end
+        end)
+        -- 200: valid id
+        it('testGetValidId', function()
+            local id = get_one_valid_id()
+            local status_code, data = get_helper(uri .. '/' .. tostring(id))
+            expect(status_code).to.equal(200)
+            expect(data).to.be.a('table')
+        end)
+        -- 500: invalid id
+        it('testGetInvalidId', function()
+            local id = 0 -- never exist
+            local status_code, data = get_helper(uri .. '/' .. tostring(id))
+            expect(status_code).to.equal(500)
+        end)
+        -- 200: valid range
+        it('testGetPostsInRange', function()
+            local status_code, data = get_helper(uri .. '/range?from=2025-01-01&to=2026-01-01')
+            expect(status_code).to.equal(200)
+            expect(data).to.be.a('table')
+            expect(#data).to_not.equal(0)
+        end)
+        -- 200: still valid but no matches
+        it('testGetRangePostsNoMatches', function()
+            local status_code, data = get_helper(uri .. '/range?from=2024-01-01&to=2025-01-01')
+            expect(status_code).to.equal(200)
+            expect(data).to.be.a('table')
+            expect(#data).to.equal(0)
+        end)
+    end)
+
+    describe('TestUpdatePostAPI', function()
+        -- 200: valid id
+        it('testValidUpdate', function()
+            local id = get_one_valid_id()
+            local status_code, data = put_helper(id, {
+                author = 'Edited',
+                content = 'Updated content'
+            })
+            expect(status_code).to.equal(200)
+            expect(data.status).to.equal('Updated')
+            expect(data.id).to.equal(id)
+        end)
+        -- 400: invalid id
+        it('testInvalidId', function()
+            local id = 'a'
+            local status_code, data = put_helper(id, {
+                author = 'Edited',
+                content = 'Updated content'
+            })
+            expect(status_code).to.equal(400)
+            expect(data.error).to.equal('Invalid post ID')
+        end)
+        -- 400: invalid schema
+        it('testInvalidSchema', function()
+            local id = get_one_valid_id()
+            local status_code, data = put_helper(id, {
+                author = 123,
+                content = 'Updated content'
+            })
+            expect(status_code).to.equal(400)
+            expect(data.error).to.contain('Invalid input')
+        end)
+        -- 404: nonexisting post
+        it('testNonexistPost', function()
+            local id = 0
+            local status_code, data = put_helper(id, {
+                author = 'Edited',
+                content = 'Updated content'
+            })
+            expect(status_code).to.equal(404)
+            expect(data.error).to.equal('Post not found')
+        end)
+    end)
+
+    describe('TestDelPostAPI', function()
+        local uri = 'http://localhost:' .. PORT .. '/posts'
+        -- 404: nonexisting post
+        it('testNonexistPost', function()
+            local id = 0
+            local status_code, data = del_helper(uri .. '/' .. tostring(id))
+            expect(status_code).to.equal(404)
+            expect(data.error).to.equal('Post not found')
+        end)
+        -- 400: invalid id
+        it('testInvalidId', function()
+            local id = 'a'
+            local status_code, data = del_helper(uri .. '/' .. tostring(id))
+            expect(status_code).to.equal(400)
+            expect(data.error).to.equal('Invalid post ID')
+        end)
+        -- 200: valid
+        it('testValidId', function()
+            local id = get_one_valid_id()
+            local status_code, data = del_helper(uri .. '/' .. tostring(id))
+            expect(status_code).to.equal(200)
+            expect(data.status).to.equal('Deleted')
+            expect(data.id).to.equal(id)
+        end)
+    end)
+    os.remove(DB_PATH)
+    os.remove(DB_PATH .. '-shm')
+    os.remove(DB_PATH .. '-wal')
+    print('TERMINATING THE SERVER')
+    -- stop the server instance
+    os.exit(0) 
+end, 3000)

--- a/tests/mock_server.lua
+++ b/tests/mock_server.lua
@@ -1,0 +1,197 @@
+-- mock server for HTTP server testing
+local M = {}
+
+function M.create(opts)
+    local PORT    = assert(opts.port, "opts.port required")
+    local DB_PATH = assert(opts.db_path, "opts.db_path required")
+
+    local server = Astra.http.server:new()
+    server.port = PORT
+
+    local db = Astra.database_connect('sqlite', DB_PATH)
+    db:execute([[
+        CREATE TABLE IF NOT EXISTS posts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            author TEXT NOT NULL,
+            title TEXT,
+            content TEXT NOT NULL,
+            timestamp INTEGER,
+            datetime text
+        );
+    ]], {});
+
+    server:get("/", function()
+        return "hello from default Astra instance!"
+    end)
+
+    -- posts
+    -- GET all posts
+    server:get('/posts', function(_, res)
+        local ok, result = pcall(function()
+            return db:query_all('SELECT * FROM posts ORDER BY timestamp DESC', {})
+        end)
+        if not ok then
+            res:set_status_code(500)
+            return { error = 'Failed to fetch posts.' }
+        end
+        return result
+    end)
+
+    -- GET posts by id
+    server:get('/posts/{id}', function(req, res)
+        local uri = req:uri()
+        local id = tonumber(string.match(uri, '^/posts/(%d+)$'))
+        local ok, result = pcall(function()
+            return db:query_one('SELECT * FROM posts WHERE id = $1', {id})
+        end)
+        if not ok then
+            res:set_status_code(500)
+            return { error = 'Failed to fetch posts.' }
+        end
+        return result
+    end)
+
+    -- GET posts by daterange
+    server:get('/posts/range', function(req, res)
+        local queries = req:queries()
+        local from_str = queries.from
+        local to_str = queries.to
+
+        local function text2timestamp(dt_str, eod)
+            local year, month, day = dt_str:match("(%d+)%-(%d+)%-(%d+)")
+            year = tonumber(year)
+            month = tonumber(month)
+            day = tonumber(day)
+            local dt
+            if eod == true then 
+                dt = Astra.datetime.new(year, month, day, 23, 59, 59.999)
+            else
+                dt = Astra.datetime.new(year, month, day, 0, 0, 0)
+            end
+            return dt:get_epoch_milliseconds()
+        end
+
+        local from_ts = text2timestamp(from_str)
+        local to_ts = text2timestamp(to_str, true)
+
+        local ok, result = pcall(function()
+            return db:query_all([[
+                SELECT * FROM posts
+                WHERE timestamp BETWEEN $1 AND $2
+                ORDER BY timestamp DESC
+            ]], { from_ts, to_ts })
+        end)
+        if not ok then
+            res:set_status_code(500)
+            return { error = 'Failed to fetch posts.' }
+        end
+        return result
+    end)
+
+    -- POST post
+    server:post('/posts', function(req, res)
+        local data = req:body():json()
+        -- schema validation
+        local schema = {
+            author = { type = 'string' },
+            title = { type = 'string', required = false },
+            content = { type = 'string' },
+        }
+        local is_valid, err = Astra.validate_table(data, schema)
+        if not is_valid then
+            res:set_status_code(400)
+            return { error = 'Invalid input: ' .. tostring(err) }
+        end
+        -- post
+        local dt_now = Astra.datetime.new()
+        local timestamp = dt_now:get_epoch_milliseconds()
+        local datetime = dt_now:to_locale_datetime_string()
+        db:execute([[
+            INSERT INTO posts (author, title, content, timestamp, datetime)
+            VALUES ($1, $2, $3, $4, $5);
+        ]], { data.author, data.title, data.content, timestamp, datetime });
+        res:set_status_code(200)
+        return { status = 'created' }
+
+    end)
+
+    -- PUT post (by id)
+    server:put('/posts/{id}', function(req, res)
+        local uri = req:uri()
+        local id = tonumber(string.match(uri, '^/posts/(%d+)$'))
+        if not id then
+            res:set_status_code(400)
+            return { error = 'Invalid post ID' }
+        end
+        local data = req:body():json()
+        -- schema validation
+        local schema = {
+            author = { type = 'string' },
+            content = { type = 'string' },
+        }
+        local is_valid, err = Astra.validate_table(data, schema)
+        if not is_valid then
+            res:set_status_code(400)
+            return { error = 'Invalid input: ' .. tostring(err) }
+        end
+        -- existence check
+        local ok, post = pcall(function()
+            return db:query_one('SELECT 1 FROM posts WHERE id = $1', {id})
+        end)
+        if not ok or not post then
+            res:set_status_code(404)
+            return { error = 'Post not found' }
+        end
+        -- update, pad the authors
+        local ok, _ = pcall(function()
+            return db:execute([[
+                UPDATE posts
+                SET 
+                    author = author || $1,
+                    content = $2
+                WHERE id = $3
+            ]], {', ' .. data.author, data.content, id})
+        end)
+        if not ok then
+            res:set_status_code(500)
+            return { error = 'Failed to update post' }
+        end
+        res:set_status_code(200)
+        return { status = 'Updated', id = id }
+    end)
+
+    -- DEL post
+    server:delete('/posts/{id}', function(req, res)
+        local uri = req:uri()
+        local id = tonumber(string.match(uri, '^/posts/(%d+)$'))
+        if not id then
+            res:set_status_code(400)
+            return { error = 'Invalid post ID' }
+        end
+        -- existence check
+        local ok, post = pcall(function()
+            return db:query_one('SELECT 1 FROM posts WHERE id = $1', {id})
+        end)
+        if not ok or not post then
+            res:set_status_code(404)
+            return { error = 'Post not found' }
+        end
+        -- deletion
+        local ok, _ = pcall(function()
+            return db:execute([[
+                DELETE FROM posts
+                WHERE id = $1
+            ]], { id })
+        end)
+        if not ok then
+            res:set_status_code(500)
+            return { error = 'Failed to delete post' }
+        end
+        res:set_status_code(200)
+        return { status = 'Deleted', id = id }
+    end)
+
+    return server
+end
+
+return M


### PR DESCRIPTION
This PR introduces a mock server and automated test suite to validate Astra’s HTTP server functionality using [Lust](https://github.com/bjornbytes/lust).

tests/mock_server.lua
	•	Implements a mock HTTP server with full CRUD operations
	•	Backed by a temporary SQLite database (posts_test.db)
tests/http_server.lua
	•	Provides end-to-end tests for POST, GET, PUT, and DELETE endpoints
	•	Uses Lust for assertions and schema validation checks
	•	Handles DB cleanup (.db, -wal, -shm) and graceful server shutdown after test execution