### PR TITLE
fix for windows: avoid colon variable parse error in PowerShell Write…

### DIFF
--- a/windows_install.ps1
+++ b/windows_install.ps1
@@ -59,7 +59,7 @@ function Test-Admin {
 
 # Default runtime
 if ($Runtime -eq "") {
-    $Runtime = "luajit"
+    Select-Runtime
 }
 
 # If help is requested, show usage and exit


### PR DESCRIPTION
Fixed a PowerShell string interpolation in windows_install.ps1 that caused an invalid variable reference error on Windows.