### PR TITLE
WebSocketMessageType was falsely annotated

### DIFF
--- a/astra/lua/http.lua
+++ b/astra/lua/http.lua
@@ -127,7 +127,7 @@ local http = {}
 
 ---@class WebSocketMessage
 ---@field type WebSocketMessageType
----@field data string
+---@field value string
 
 ---@class WebSocket
 ---Receive another message. Returns `nil` if the stream has closed.

--- a/astra/teal/http.tl
+++ b/astra/teal/http.tl
@@ -128,7 +128,7 @@ local enum WebSocketMessageType "text" "bytes" "ping" "pong" "close" end
 
 global interface WebSocketMessage
     type: WebSocketMessageType
-    data: string
+    value: string
 end
 
 global interface WebSocket is userdata


### PR DESCRIPTION
the rust code returns 'value' rather than 'data'